### PR TITLE
fix: Added null check for nodeData.any

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ class wdioAxe {
                     delete nodeData.all;
                     delete nodeData.none;
                     if (calledMethod !== 'getBestPractice' && calledMethod !== 'analyseWithTag') {
-                        violation.message = nodeData.any[0].message;
+                        if (nodeData.any.length > 0) {
+                            violation.message = nodeData.any[0].message;
+                        } else {
+                            violation.message = nodeData.failureSummary;
+                        }
                     }
                     violation.html = nodeData.html;
                     violation.target = JSON.stringify(nodeData.target);


### PR DESCRIPTION
Added null check for nodeData.any as there are cases where is is empty, and fallback to assigning the failureSummary as the message

<img width="1644" alt="Screen Shot 2021-08-20 at 5 32 23 pm" src="https://user-images.githubusercontent.com/48502210/130198868-c3cbcdc4-d824-43a3-948f-95c6e2ae093f.png">

When nodeData.any was empty, `getViolations()` function fails as a result with the following error message:
`wdio-axe encountered an error. Check the config and try to re run again.`